### PR TITLE
Change default blueprint name

### DIFF
--- a/Home_Assistant/blueprints/hasp_Activate_Page_on_Idle.yaml
+++ b/Home_Assistant/blueprints/hasp_Activate_Page_on_Idle.yaml
@@ -1,5 +1,5 @@
 blueprint:
-  name: "HASP p[x].b[y] activates a selected page after a specified period of inactivity"
+  name: "HASP p[x].sec[x] activates a selected page after a specified period of inactivity"
   description: |
 
     # Description


### PR DESCRIPTION
Remove '.b[y]' and add '.sec[x]' to the name because the automation doesn't apply to a button, but references a second/time.
I thought about if this should be 's' or 'sec', but concluded that 's' was too like 'b' - both being single letters - and so sec better reflected the default information that should go there.