### PR TITLE
Removed web page race condition in nextionHandleInput

### DIFF
--- a/Arduino_Sketch/HASwitchPlate/HASwitchPlate.ino
+++ b/Arduino_Sketch/HASwitchPlate/HASwitchPlate.ino
@@ -812,7 +812,6 @@ void nextionHandleInput()
       nextionProcessInput();
     }
 
-    webServer.handleClient(); // webServer loop
     telnetHandleClient();     // telnet client loop
     yield();
   }


### PR DESCRIPTION
Removed call to webServer.handleClient() in nextionHandleInput() which could cause the event loop() to lock up.